### PR TITLE
[FOS-11291] Fix prerelease type initialization.

### DIFF
--- a/include/semver/version.hpp
+++ b/include/semver/version.hpp
@@ -242,8 +242,9 @@ namespace semver {
             m_minor             = 0;
             m_patch             = 0;
             m_build             = "";
-            m_pre_release       = "";
+            m_pre_release_type  = PRE_RELEASE_NONE;
             m_pre_release_id    = "";
+            m_pre_release       = "";
             m_is_stable         = true;
 
             if (version.empty())

--- a/test/semver/version.cpp
+++ b/test/semver/version.cpp
@@ -356,6 +356,9 @@ BOOST_AUTO_TEST_CASE(test_comparator_suite)
     semver::version v1beta11("1.0.0-beta.11");
     semver::version v1rc1("1.0.0-rc.1");
     semver::version v1("1.0.0");
+    semver::version cur_doos("2.11.0-1");
+    semver::version max_doos("2.11.0-3");
+    semver::version min_doos("2.10.0-1");
 
     BOOST_CHECK_EQUAL(empty < v0, true);
     BOOST_CHECK_EQUAL(v0 < v1alpha, true);
@@ -366,6 +369,15 @@ BOOST_AUTO_TEST_CASE(test_comparator_suite)
     BOOST_CHECK_EQUAL(v1beta2 < v1beta11, true);
     BOOST_CHECK_EQUAL(v1beta11 < v1rc1, true);
     BOOST_CHECK_EQUAL(v1rc1 < v1, true);
+
+    BOOST_CHECK_EQUAL(max_doos <= cur_doos , true);
+    BOOST_CHECK_EQUAL(cur_doos >= max_doos, true);
+
+    BOOST_CHECK_EQUAL(max_doos >= cur_doos , false);
+    BOOST_CHECK_EQUAL(cur_doos <= max_doos, false);
+
+    BOOST_CHECK_EQUAL(cur_doos > max_doos, false);
+    BOOST_CHECK_EQUAL(cur_doos < min_doos, false);
 }
 
 BOOST_AUTO_TEST_CASE(test_stream)

--- a/test/semver/version.cpp
+++ b/test/semver/version.cpp
@@ -345,18 +345,27 @@ BOOST_AUTO_TEST_CASE(test_comparator)
 
 BOOST_AUTO_TEST_CASE(test_comparator_suite)
 {
-    semver::version cur_doos("2.11.0-1");
-    semver::version max_doos("2.11.0-3");
-    semver::version min_doos("2.10.0-1");
+    // "empty" < 0.1.0 < 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+    semver::version empty;
+    semver::version v0("0.1.0");
+    semver::version v1alpha("1.0.0-alpha");
+    semver::version v1alpha1("1.0.0-alpha.1");
+    semver::version v1alphabeta("1.0.0-alpha.beta");
+    semver::version v1beta("1.0.0-beta");
+    semver::version v1beta2("1.0.0-beta.2");
+    semver::version v1beta11("1.0.0-beta.11");
+    semver::version v1rc1("1.0.0-rc.1");
+    semver::version v1("1.0.0");
 
-    BOOST_CHECK_EQUAL(max_doos <= cur_doos , true);
-    BOOST_CHECK_EQUAL(cur_doos >= max_doos, true);
-
-    BOOST_CHECK_EQUAL(max_doos >= cur_doos , false);
-    BOOST_CHECK_EQUAL(cur_doos <= max_doos, false);
-
-    BOOST_CHECK_EQUAL(cur_doos > max_doos, false);
-    BOOST_CHECK_EQUAL(cur_doos < min_doos, false);
+    BOOST_CHECK_EQUAL(empty < v0, true);
+    BOOST_CHECK_EQUAL(v0 < v1alpha, true);
+    BOOST_CHECK_EQUAL(v1alpha < v1alpha1, true);
+    BOOST_CHECK_EQUAL(v1alpha1 < v1alphabeta, true);
+    BOOST_CHECK_EQUAL(v1alphabeta < v1beta, true);
+    BOOST_CHECK_EQUAL(v1beta < v1beta2, true);
+    BOOST_CHECK_EQUAL(v1beta2 < v1beta11, true);
+    BOOST_CHECK_EQUAL(v1beta11 < v1rc1, true);
+    BOOST_CHECK_EQUAL(v1rc1 < v1, true);
 }
 
 BOOST_AUTO_TEST_CASE(test_stream)

--- a/test/semver/version.cpp
+++ b/test/semver/version.cpp
@@ -345,30 +345,9 @@ BOOST_AUTO_TEST_CASE(test_comparator)
 
 BOOST_AUTO_TEST_CASE(test_comparator_suite)
 {
-    // "empty" < 0.1.0 < 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
-    semver::version empty;
-    semver::version v0("0.1.0");
-    semver::version v1alpha("1.0.0-alpha");
-    semver::version v1alpha1("1.0.0-alpha.1");
-    semver::version v1alphabeta("1.0.0-alpha.beta");
-    semver::version v1beta("1.0.0-beta");
-    semver::version v1beta2("1.0.0-beta.2");
-    semver::version v1beta11("1.0.0-beta.11");
-    semver::version v1rc1("1.0.0-rc.1");
-    semver::version v1("1.0.0");
     semver::version cur_doos("2.11.0-1");
     semver::version max_doos("2.11.0-3");
     semver::version min_doos("2.10.0-1");
-
-    BOOST_CHECK_EQUAL(empty < v0, true);
-    BOOST_CHECK_EQUAL(v0 < v1alpha, true);
-    BOOST_CHECK_EQUAL(v1alpha < v1alpha1, true);
-    BOOST_CHECK_EQUAL(v1alpha1 < v1alphabeta, true);
-    BOOST_CHECK_EQUAL(v1alphabeta < v1beta, true);
-    BOOST_CHECK_EQUAL(v1beta < v1beta2, true);
-    BOOST_CHECK_EQUAL(v1beta2 < v1beta11, true);
-    BOOST_CHECK_EQUAL(v1beta11 < v1rc1, true);
-    BOOST_CHECK_EQUAL(v1rc1 < v1, true);
 
     BOOST_CHECK_EQUAL(max_doos <= cur_doos , true);
     BOOST_CHECK_EQUAL(cur_doos >= max_doos, true);


### PR DESCRIPTION
Without this change a version of the form `x.y.z-b`, where `b` does not start with `alpha`, `beta`, or `rc` could result in erroneous comparison results.

An example is `semver::version("2.11.0-1") < semver::version("2.11.0-3")` may sometimes be true and other times be false.